### PR TITLE
Add .NET Core 3.1 build to TestCentric.Engine.Core package

### DIFF
--- a/cake/build-settings.cake
+++ b/cake/build-settings.cake
@@ -335,7 +335,11 @@ public class BuildSettings
 					"testcentric.engine.metadata.dll", "testcentric.extensibility.dll"),
 				HasDirectory("lib/netstandard2.0").WithFiles(
 					"testcentric.engine.core.dll", "testcentric.engine.core.pdb", "nunit.engine.api.dll",
-					"testcentric.engine.metadata.dll", "testcentric.extensibility.dll")
+					"testcentric.engine.metadata.dll", "testcentric.extensibility.dll"),
+				HasDirectory("lib/netcoreapp3.1").WithFiles(
+					"testcentric.engine.core.dll", "testcentric.engine.core.pdb", "nunit.engine.api.dll",
+					"testcentric.engine.metadata.dll", "testcentric.extensibility.dll",
+					"Microsoft.Extensions.DependencyModel.dll")
 			});
 
 		EngineApiPackage = new NuGetPackageDefinition(

--- a/nuget/TestCentric.Engine.Core.nuspec
+++ b/nuget/TestCentric.Engine.Core.nuspec
@@ -34,10 +34,17 @@
 	<file src="src/TestEngine/testcentric.engine.core/bin/Release/net462/testcentric.engine.metadata.dll" target="lib/net462" />
 	<file src="src/TestEngine/testcentric.engine.core/bin/Release/net462/testcentric.extensibility.dll" target="lib/net462" />
 
-	<file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/nunit.engine.api.dll" target="lib/netstandard2.0" />
-    <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.core.dll" target="lib/netstandard2.0" />
-    <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.core.pdb" target="lib/netstandard2.0" />
-	<file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.metadata.dll" target="lib/netstandard2.0" />
-	<file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.extensibility.dll" target="lib/netstandard2.0" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/nunit.engine.api.dll" target="lib/netstandard2.0" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.core.dll" target="lib/netstandard2.0" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.core.pdb" target="lib/netstandard2.0" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.engine.metadata.dll" target="lib/netstandard2.0" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netstandard2.0/testcentric.extensibility.dll" target="lib/netstandard2.0" />
+
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/nunit.engine.api.dll" target="lib/netcoreapp3.1" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/testcentric.engine.core.dll" target="lib/netcoreapp3.1" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/testcentric.engine.core.pdb" target="lib/netcoreapp3.1" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/testcentric.engine.metadata.dll" target="lib/netcoreapp3.1" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/testcentric.extensibility.dll" target="lib/netcoreapp3.1" />
+	  <file src="src/TestEngine/testcentric.engine.core/bin/Release/netcoreapp3.1/Microsoft.Extensions.DependencyModel.dll" target="lib/netcoreapp3.1" />
   </files>
 </package>


### PR DESCRIPTION
Fixes #83