### PR TITLE
Eliminate ITransport interface

### DIFF
--- a/src/TestEngine/testcentric.engine/Communication/Transports/ITestAgencyTransport.cs
+++ b/src/TestEngine/testcentric.engine/Communication/Transports/ITestAgencyTransport.cs
@@ -5,7 +5,7 @@
 
 namespace TestCentric.Engine.Communication.Transports
 {
-    public interface ITestAgencyTransport : ITransport
+    public interface ITestAgencyTransport
     {
         string ServerUrl { get; }
     }

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -44,8 +44,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Core" Version="2.0.0-dev00026" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00028" />
+		<PackageReference Include="TestCentric.Engine.Core" Version="2.0.0-dev00028" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00030" />
 		<PackageReference Include="TestCentric.Metadata" Version="2.0.0" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.0.0" />


### PR DESCRIPTION
We don't actually use the interface, which has been dropped from Engine.Core, so stop using it as a base for ITestAgencyTransport.