### PR TITLE
Force stop: reset again+runner 

### DIFF
--- a/src/TestEngine/testcentric.engine/Runners/AssemblyRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/AssemblyRunner.cs
@@ -204,6 +204,9 @@ namespace TestCentric.Engine.Runners
                 {
                     log.Error("Failed to stop the remote run. {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 }
+
+                _agent = null;
+                _remoteRunner = null;
             }
         }
 

--- a/src/TestEngine/testcentric.engine/Services/TestEventDispatcher.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestEventDispatcher.cs
@@ -32,6 +32,7 @@ namespace TestCentric.Engine.Services
 
         public void InitializeForRun()
         {
+            _runCancelled = false;
             _workItemTracker.Clear();
             _allItemsComplete.Reset();
             Listeners = new List<ITestEventListener>(_listenerExtensions);


### PR DESCRIPTION
This PR solves issue #[1144 ](https://github.com/TestCentric/testcentric-gui/issues/1144) reported in the TestCentric GUI project.

When a forced stop is executed on a test run the entire agent process is getting terminated. We cannot use the identical agent or runner for the next test run, but instead we need to create new ones. However the member variables still references the outdated agent and continue trying to communicate with it.

The fix resets these two member variables so that the agent and runner are created newly with the next test run.

In addition also a small fix in the `TestEventDispatcher` class was required:
When a force stop is executed the `_runCancelled` variable is set to true. In this state no test events are fired anymore. 
However there is no code location which reset this variable back to false, so as consequence the agent will not fire any events at all once force stop was executed. 
I was not sure in which code location to add the reset of this variable best. But finally decided to place it into the method `InitializeForRun`. This means whenever a new test run starts, this variable is reset.

Overall the scenario mentioned in the issue will be fixed by this PR.