### PR TITLE
Dispose AssemblyDefinition objects to release file handle properly

### DIFF
--- a/src/TestEngine/testcentric.engine/Services/TestFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestFrameworkService.cs
@@ -44,15 +44,17 @@ namespace TestCentric.Engine.Services
 
         private AssemblyName FindReferencedTestFramework(string assemblyName)
         {
-            var assembly = AssemblyDefinition.ReadAssembly(assemblyName);
+            using (var assembly = AssemblyDefinition.ReadAssembly(assemblyName))
+            {
 
-            foreach (var reference in assembly.MainModule.AssemblyReferences)
-                foreach (string name in KnownFrameworks)
-                    if (reference.Name == name)
-                    {
-                        log.Debug($"Assembly {assemblyName} uses test framework {name}, version {reference.Version}");
-                        return new AssemblyName(reference.FullName);
-                    }
+                foreach (var reference in assembly.MainModule.AssemblyReferences)
+                    foreach (string name in KnownFrameworks)
+                        if (reference.Name == name)
+                        {
+                            log.Debug($"Assembly {assemblyName} uses test framework {name}, version {reference.Version}");
+                            return new AssemblyName(reference.FullName);
+                        }
+            }
 
             return null;
         }


### PR DESCRIPTION
This PR resolves #218 by adding missing dispose calls for two `AssemblyDefinition` instances.

An AssemblyDefinition class receives a filename (string) as input and opens a stream to read the assembly content. Exactly this open stream blocks the file handle and thus the assembly cannot be replaced by the compile operation.

The AssemblyDefinition class already provide a Dispose method to close/unblock the stream object, however it wasn't called so far. So the fix is pretty easy, it was much harder to find the problem in the first place.

I was able to successfully execute the usecase with this fix and also observe in the Resource Monitor that the file handle is no longer blocked.