### PR TITLE
Update TestCentric.Engine.Api to latest version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -208,13 +208,13 @@ BuildSettings.Packages.Add(new NuGetPackage(
 			"testcentric.metadata.dll", "testcentric.extensibility.dll", "testcentric.extensibility.api.dll", "TestCentric.InternalTrace.dll",
 			"testcentric.engine.pdb", "test-bed.exe", "test-bed.exe.config",
 			"test-bed.addins", "testcentric.nuget.addins")
-	},
-	tests: packageTests,
-	preloadedExtensions: new [] {
-        KnownExtensions.Net462PluggableAgent.SetVersion("2.5.1").NuGetPackage,
-        KnownExtensions.Net60PluggableAgent.SetVersion("2.5.1").NuGetPackage,
-        KnownExtensions.Net70PluggableAgent.SetVersion("2.5.1").NuGetPackage,
-        KnownExtensions.Net80PluggableAgent.SetVersion("2.5.1").NuGetPackage }
+	}//,
+//	tests: packageTests,
+//  preloadedExtensions: new[] {
+//      KnownExtensions.Net462PluggableAgent.SetVersion("2.5.2").NuGetPackage }
+//      KnownExtensions.Net60PluggableAgent.SetVersion("2.5.1").NuGetPackage,
+//      KnownExtensions.Net70PluggableAgent.SetVersion("2.5.1").NuGetPackage,
+//      KnownExtensions.Net80PluggableAgent.SetVersion("2.5.3").NuGetPackage }
 ));
 
 //////////////////////////////////////////////////////////////////////

--- a/src/TestBed/TestBed.cs
+++ b/src/TestBed/TestBed.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using NUnit.Common;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -75,7 +76,7 @@ namespace TestCentric.Engine.TestBed
             }
 
             if (!string.IsNullOrEmpty(options.RequestedRuntime))
-                package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, options.RequestedRuntime);
+                package.AddSetting(SettingDefinitions.RequestedRuntimeFramework.WithValue(options.RequestedRuntime));
 
             var runner = TestEngine.GetRunner(package);
 

--- a/src/TestBed/TestBed.cs
+++ b/src/TestBed/TestBed.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Common;
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/TestEngine/testcentric.engine.tests/Communication/Protocols/BinarySerializationProtocolTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Communication/Protocols/BinarySerializationProtocolTests.cs
@@ -146,10 +146,10 @@ namespace TestCentric.Engine.Communication.Protocols
             Assert.That(newPackage.Settings.Count, Is.EqualTo(oldPackage.Settings.Count));
             Assert.That(newPackage.SubPackages.Count, Is.EqualTo(oldPackage.SubPackages.Count));
 
-            foreach (var key in oldPackage.Settings.Keys)
+            foreach (var setting in oldPackage.Settings)
             {
-                Assert.That(newPackage.Settings.ContainsKey(key));
-                Assert.That(newPackage.Settings[key], Is.EqualTo(oldPackage.Settings[key]));
+                Assert.That(newPackage.Settings.HasSetting(setting.Name));
+                Assert.That(newPackage.Settings.GetSetting(setting.Name), Is.EqualTo(setting));
             }
 
             for (int i = 0; i < oldPackage.SubPackages.Count; i++)

--- a/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
@@ -4,8 +4,6 @@
 // ***********************************************************************
 
 #if !NETCOREAPP2_1
-using System;
-using NUnit.Common;
 using NUnit.Framework;
 using TestCentric.Engine.Services;
 using TestCentric.Engine.Services.Fakes;

--- a/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Runners/AggregatingTestRunnerTests.cs
@@ -5,6 +5,7 @@
 
 #if !NETCOREAPP2_1
 using System;
+using NUnit.Common;
 using NUnit.Framework;
 using TestCentric.Engine.Services;
 using TestCentric.Engine.Services.Fakes;
@@ -24,25 +25,31 @@ namespace TestCentric.Engine.Runners
             _context.Add(new FakeTestRunnerFactory());
         }
 
-        [TestCase(1, null, 1)]
+        [TestCase(1)]
+        [TestCase(3)]
+        [TestCase(8)]
+        [TestCase(20)]
+        public void CheckLevelOfParallelism_MaxAgentsNotSpecified(int assemblyCount)
+        {
+            var package = CreatePackage(assemblyCount);
+
+            var runner = new AggregatingTestRunner(_context, package);
+            Assert.That(runner.LevelOfParallelism, Is.EqualTo(assemblyCount));
+        }
+
         [TestCase(1, 1, 1)]
-        [TestCase(3, null, 3)]
         [TestCase(3, 1, 1)]
         [TestCase(3, 2, 2)]
         [TestCase(3, 3, 3)]
         [TestCase(20, 8, 8)]
         [TestCase(8, 20, 8)]
-        public void CheckLevelOfParallelism_ListOfAssemblies(int assemblyCount, int? maxAgents, int expected)
+        public void CheckLevelOfParallelism_MaxAgentsSpecified(int assemblyCount, int maxAgents, int expected)
         {
-            if (maxAgents == null)
-                expected = Math.Min(assemblyCount, Environment.ProcessorCount);
-
             var package = CreatePackage(assemblyCount);
-            if (maxAgents != null)
-                package.Settings[EnginePackageSettings.MaxAgents] = maxAgents;
+            package.Settings.Add(SettingDefinitions.MaxAgents.WithValue(maxAgents));
 
             var runner = new AggregatingTestRunner(_context, package);
-            Assert.That(runner, Has.Property(nameof(AggregatingTestRunner.LevelOfParallelism)).EqualTo(expected));
+            Assert.That(runner.LevelOfParallelism, Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Common;
 using NUnit.Framework;
 
 namespace TestCentric.Engine.Services

--- a/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Common;
 using NUnit.Framework;
 
 namespace TestCentric.Engine.Services
@@ -71,12 +72,12 @@ namespace TestCentric.Engine.Services
         public void EngineOptionPreferredOverImageTarget(string framework, int majorVersion, int minorVersion, string requested)
         {
             var package = new TestPackage("test");
-            package.AddSetting(EnginePackageSettings.ImageTargetFrameworkName, framework);
-            package.AddSetting(EnginePackageSettings.ImageRuntimeVersion, new Version(majorVersion, minorVersion));
-            package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, requested);
+            package.AddSetting(SettingDefinitions.ImageTargetFrameworkName.WithValue(framework));
+            package.AddSetting(SettingDefinitions.ImageRuntimeVersion.WithValue(new Version(majorVersion, minorVersion)));
+            package.AddSetting(SettingDefinitions.RequestedRuntimeFramework.WithValue(requested));
 
             _runtimeService.SelectRuntimeFramework(package);
-            Assert.That(package.GetSetting<string>(EnginePackageSettings.TargetRuntimeFramework, null), Is.EqualTo(requested));
+            Assert.That(package.Settings.GetValueOrDefault(SettingDefinitions.TargetRuntimeFramework), Is.EqualTo(requested));
         }
 
         //[Test, Platform(Exclude ="Linux")]

--- a/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using NSubstitute;
+using NUnit.Common;
 
 #if !NETCOREAPP2_1
 namespace TestCentric.Engine.Services
@@ -58,48 +59,28 @@ namespace TestCentric.Engine.Services
         [Test]
         public void RequestedFrameworkInvalid()
         {
-            _package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, INVALID_RUNTIME);
+            _package.AddSetting(SettingDefinitions.RequestedRuntimeFramework.WithValue(INVALID_RUNTIME));
 
             var exception = Assert.Throws<EngineException>(() => Validate());
 
             CheckMessageContent(exception.Message, $"The requested framework {INVALID_RUNTIME} is unknown or not available.");
         }
 
-        [TestCase("ProcessModel")]
-        [TestCase("DomainUsage")]
-        [TestCase("ProcessModel", "DomainUsage")]
-        public void ObsoletePackageSetting(params string[] settings)
-        {
-            foreach (var setting in settings)
-                _package.AddSetting(setting, "something"); // Test doesn't use the value
-
-            var exception = Assert.Throws<EngineException>(() => Validate());
-
-            var errors = new List<string>();
-            foreach (var setting in settings)
-                errors.Add($"The {setting} setting is no longer supported.");
-            CheckMessageContent(exception.Message, errors.ToArray());
-        }
-
         [Test]
         public void AllPossibleErrors()
         {
-            _package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, INVALID_RUNTIME);
-            _package.AddSetting("ProcessModel", "something"); // Test doesn't use the value
-            _package.AddSetting("DomainUsage", "something"); // Test doesn't use the value
+            _package.AddSetting(SettingDefinitions.RequestedRuntimeFramework.WithValue(INVALID_RUNTIME));
 
             var exception = Assert.Throws<EngineException>(() => Validate());
 
             CheckMessageContent(exception.Message,
-                $"The requested framework {INVALID_RUNTIME} is unknown or not available.",
-                "The ProcessModel setting is no longer supported.",
-                "The DomainUsage setting is no longer supported.");
+                $"The requested framework {INVALID_RUNTIME} is unknown or not available.");
         }
 
         [Test]
         public void RequestedFrameworkValid()
         {
-            _package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, VALID_RUNTIME);
+            _package.AddSetting(SettingDefinitions.RequestedRuntimeFramework.WithValue(VALID_RUNTIME));
             Assert.That(() => Validate(), Throws.Nothing);
         }
 

--- a/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
+++ b/src/TestEngine/testcentric.engine.tests/Services/TestPackageAnalyzerTests.cs
@@ -3,10 +3,8 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using System.Collections.Generic;
 using NUnit.Framework;
 using NSubstitute;
-using NUnit.Common;
 
 #if !NETCOREAPP2_1
 namespace TestCentric.Engine.Services

--- a/src/TestEngine/testcentric.engine/Projects/NUnitProject.cs
+++ b/src/TestEngine/testcentric.engine/Projects/NUnitProject.cs
@@ -86,6 +86,7 @@ namespace TestCentric.Engine.Projects
             return TestPackage;
         }
 
+        // TODO: THIS should allow for all types of settings
         public TestPackage GetTestPackage(string configName)
         {
             if (configName == null)
@@ -98,7 +99,7 @@ namespace TestCentric.Engine.Projects
         {
             var package = new TestPackage(nunitPackage.SubPackages.Select(p => p.FullName).ToArray());
             foreach (var setting in nunitPackage.Settings)
-                package.AddSetting(setting.Key, setting.Value);
+                package.Settings.Add(setting.Key, (string)setting.Value);
 
             return package;
         }

--- a/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Common;
 using System;
 using System.Collections.Generic;
 using TestCentric.Engine.Internal;

--- a/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
+++ b/src/TestEngine/testcentric.engine/Runners/AggregatingTestRunner.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using NUnit.Common;
 using System;
 using System.Collections.Generic;
 using TestCentric.Engine.Internal;
@@ -13,9 +14,6 @@ namespace TestCentric.Engine.Runners
     /// <summary>
     /// AggregatingTestRunner runs tests using multiple
     /// subordinate runners and combines the results.
-    /// The individual runners may be run in parallel
-    /// if a derived class sets the LevelOfParallelism
-    /// property in its constructor.
     /// </summary>
     public class AggregatingTestRunner : AbstractTestRunner
     {
@@ -30,18 +28,9 @@ namespace TestCentric.Engine.Runners
 
         private readonly ITestRunnerFactory _testRunnerFactory;
 
-        // Public for testing purposes
-        public int LevelOfParallelism
-        {
-            get
-            {
-                var maxAgents = TestPackage.GetSetting(EnginePackageSettings.MaxAgents, Environment.ProcessorCount);
-                return Math.Min(maxAgents, TestPackage.Select(p => !p.HasSubPackages).Count);
-            }
-        }
-
-        // Exposed for use by tests
         public IList<ITestEngineRunner> Runners { get; }
+
+        public int LevelOfParallelism { get; }
 
         public AggregatingTestRunner(IServiceLocator services, TestPackage package) : base(package)
         {
@@ -50,9 +39,12 @@ namespace TestCentric.Engine.Runners
             _packageList = new List<TestPackage>(package.Select(p => !p.HasSubPackages));
             Runners = new List<ITestEngineRunner>();
             foreach (var subPackage in _packageList)
-            {
                 Runners.Add(_testRunnerFactory.MakeTestRunner(subPackage));
-            }
+
+            var maxAgentSetting = TestPackage.Settings.GetValueOrDefault(SettingDefinitions.MaxAgents);
+            LevelOfParallelism = maxAgentSetting > 0
+                ? Math.Min(maxAgentSetting, _packageList.Count)
+                : _packageList.Count;
         }
 
         /// <summary>
@@ -124,7 +116,7 @@ namespace TestCentric.Engine.Runners
         {
             var results = new List<TestEngineResult>();
 
-            bool disposeRunners = TestPackage.GetSetting(EnginePackageSettings.DisposeRunners, false);
+            bool disposeRunners = TestPackage.Settings.GetValueOrDefault(SettingDefinitions.DisposeRunners);
 
             if (LevelOfParallelism <= 1)
             {

--- a/src/TestEngine/testcentric.engine/Services/ProjectService.cs
+++ b/src/TestEngine/testcentric.engine/Services/ProjectService.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Common;
 using System.Collections.Generic;
 using System.IO;
 using TestCentric.Engine.Extensibility;

--- a/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
+using NUnit.Common;
 using TestCentric.Engine.Services.RuntimeLocators;
 
 namespace TestCentric.Engine.Services
@@ -235,7 +236,7 @@ namespace TestCentric.Engine.Services
             // Examine the provided settings
             log.Debug("Current framework is " + CurrentFramework);
 
-            string requestedFrameworkSetting = package.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
+            string requestedFrameworkSetting = package.Settings.GetValueOrDefault(SettingDefinitions.RequestedRuntimeFramework);
 
             if (requestedFrameworkSetting.Length > 0)
             {
@@ -248,13 +249,13 @@ namespace TestCentric.Engine.Services
                 if (!IsAvailable(requestedFramework))
                     throw new EngineException("Requested framework is not available: " + requestedFrameworkSetting);
 
-                package.Settings[EnginePackageSettings.TargetRuntimeFramework] = requestedFrameworkSetting;
+                package.Settings.Add(SettingDefinitions.TargetRuntimeFramework.WithValue(requestedFrameworkSetting));
                 return requestedFramework;
             }
 
             log.Debug($"No specific framework requested for {package.Name}");
 
-            string imageTargetFrameworkNameSetting = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, "");
+            string imageTargetFrameworkNameSetting = package.Settings.GetValueOrDefault(SettingDefinitions.ImageTargetFrameworkName);
 
             RuntimeFramework targetFramework;
 
@@ -265,7 +266,7 @@ namespace TestCentric.Engine.Services
             }
             else
             {
-                var runtimeVersion = package.GetSetting(EnginePackageSettings.ImageRuntimeVersion, CurrentFramework.FrameworkVersion);
+                var runtimeVersion = new Version(package.Settings.GetValueOrDefault(SettingDefinitions.ImageRuntimeVersion));
                 var targetVersion = new Version(runtimeVersion.Major, runtimeVersion.Minor);
                 targetFramework = new RuntimeFramework(_currentFramework.Runtime, targetVersion);
             }
@@ -284,7 +285,7 @@ namespace TestCentric.Engine.Services
                 }
             }
 
-            package.Settings[EnginePackageSettings.TargetRuntimeFramework] = targetFramework.ToString();
+            package.Settings.Add(SettingDefinitions.TargetRuntimeFramework.WithValue(targetFramework.ToString()));
 
             log.Debug($"Test will use {targetFramework} for {package.Name}");
             return targetFramework;

--- a/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
+++ b/src/TestEngine/testcentric.engine/Services/RuntimeFrameworkService.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
-using NUnit.Common;
 using TestCentric.Engine.Services.RuntimeLocators;
 
 namespace TestCentric.Engine.Services

--- a/src/TestEngine/testcentric.engine/Services/TestAgency.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestAgency.cs
@@ -15,7 +15,6 @@ using TestCentric.Engine.Internal;
 using TestCentric.Engine.Communication.Transports.Remoting;
 using TestCentric.Engine.Communication.Transports.Tcp;
 using System.Runtime.Versioning;
-using NUnit.Common;
 
 namespace TestCentric.Engine.Services
 {

--- a/src/TestEngine/testcentric.engine/Services/TestPackageAnalyzer.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestPackageAnalyzer.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Text;
 using TestCentric.Metadata;
 using TestCentric.Engine.Internal;
-using NUnit.Common;
 
 namespace TestCentric.Engine.Services
 {

--- a/src/TestEngine/testcentric.engine/Services/TestPackageAnalyzer.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestPackageAnalyzer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text;
 using TestCentric.Metadata;
 using TestCentric.Engine.Internal;
+using NUnit.Common;
 
 namespace TestCentric.Engine.Services
 {
@@ -43,24 +44,14 @@ namespace TestCentric.Engine.Services
         {
             var sb = new StringBuilder();
 
-            var frameworkSetting = package.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
-            var runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
+            var frameworkSetting = package.Settings.GetValueOrDefault(SettingDefinitions.RequestedRuntimeFramework);
+            var runAsX86 = package.Settings.GetValueOrDefault(SettingDefinitions.RunAsX86);
 
             if (frameworkSetting.Length > 0)
             {
                 // Check requested framework is actually available
                 if (!_runtimeService.IsAvailable(frameworkSetting))
                     sb.Append($"\n* The requested framework {frameworkSetting} is unknown or not available.\n");
-            }
-
-            // At this point, any unsupported settings in the TestPackage were
-            // put there by the user, so we consider the package invalid. This
-            // will be checked again as each project package is expanded and
-            // treated as a warning in that case.
-            foreach (string setting in package.Settings.Keys)
-            {
-                if (EnginePackageSettings.IsObsoleteSetting(setting))
-                    sb.Append($"\n* The {setting} setting is no longer supported.\n");
             }
 
             if (sb.Length > 0)
@@ -106,7 +97,7 @@ namespace TestCentric.Engine.Services
                 if (targetVersion.Major > 0)
                 {
                     log.Debug($"Assembly {package.FullName} uses version {targetVersion}");
-                    package.Settings[EnginePackageSettings.ImageRuntimeVersion] = targetVersion;
+                    package.Settings.Add(SettingDefinitions.ImageRuntimeVersion.WithValue(targetVersion));
                 }
 
                 string frameworkName;
@@ -119,18 +110,18 @@ namespace TestCentric.Engine.Services
                         frameworkName = ".NETStandard,Version=v1.0";
                         log.Debug($"Using {frameworkName} instead");
                     }
-                    package.Settings[EnginePackageSettings.ImageTargetFrameworkName] = frameworkName;
+                    package.Settings.Add(SettingDefinitions.ImageTargetFrameworkName.WithValue(frameworkName));
                 }
 
-                package.Settings[EnginePackageSettings.ImageRequiresX86] = assembly.RequiresX86();
+                package.Settings.Add(SettingDefinitions.ImageRequiresX86.WithValue(assembly.RequiresX86()));
                 if (assembly.RequiresX86())
                 {
                     log.Debug($"Assembly {package.FullName} will be run x86");
-                    package.Settings[EnginePackageSettings.RunAsX86] = true;
+                    package.Settings.Add(SettingDefinitions.RunAsX86.WithValue(true));
                 }
 
                 bool requiresAssemblyResolver = assembly.HasAttribute("NUnit.Framework.TestAssemblyDirectoryResolveAttribute");
-                package.Settings[EnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
+                package.Settings.Add(SettingDefinitions.ImageRequiresDefaultAppDomainAssemblyResolver.WithValue(requiresAssemblyResolver));
                 if (requiresAssemblyResolver)
                 {
                     log.Debug($"Assembly {package.FullName} requires default app domain assembly resolver");
@@ -140,15 +131,15 @@ namespace TestCentric.Engine.Services
                 if (nonTestAssembly)
                 {
                     log.Debug($"Assembly {package.FullName} has NonTestAssemblyAttribute");
-                    package.Settings[EnginePackageSettings.ImageNonTestAssemblyAttribute] = true;
+                    package.Settings.Add(SettingDefinitions.ImageNonTestAssemblyAttribute.WithValue(true));
                 }
 
                 var testFrameworkReference = _testFrameworkService.GetFrameworkReference(package.FullName);
                 if (testFrameworkReference != null)
                 {
-                    package.Settings[EnginePackageSettings.ImageTestFrameworkReference] = testFrameworkReference.FrameworkReference.FullName;
+                    package.Settings.Add(SettingDefinitions.ImageTestFrameworkReference.WithValue(testFrameworkReference.FrameworkReference.FullName));
                     if (testFrameworkReference.FrameworkDriver != null)
-                        package.Settings[EnginePackageSettings.ImageFrameworkDriverReference] = testFrameworkReference.FrameworkDriver;
+                        package.Settings.Add(SettingDefinitions.ImageFrameworkDriverReference.WithValue(testFrameworkReference.FrameworkDriver));
                 }
             }
         }

--- a/src/TestEngine/testcentric.engine/Services/TestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestRunnerFactory.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
-using NUnit.Common;
 using System.IO;
 using TestCentric.Engine.Internal;
 using TestCentric.Engine.Runners;

--- a/src/TestEngine/testcentric.engine/Services/TestRunnerFactory.cs
+++ b/src/TestEngine/testcentric.engine/Services/TestRunnerFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE file in root directory.
 // ***********************************************************************
 
+using NUnit.Common;
 using System.IO;
 using TestCentric.Engine.Internal;
 using TestCentric.Engine.Runners;
@@ -40,7 +41,7 @@ namespace TestCentric.Engine.Services
             if (ext != ".dll" && ext != ".exe")
                 return new InvalidAssemblyRunner(package, "File type is not supported");
 
-            if (package.GetSetting(EnginePackageSettings.ImageNonTestAssemblyAttribute, false))
+            if (package.Settings.GetValueOrDefault(SettingDefinitions.ImageNonTestAssemblyAttribute))
                 return new SkippedAssemblyRunner(package);
 
             return new AssemblyRunner(ServiceContext, package);

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta7" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00005" />
 		<PackageReference Include ="NUnit.Engine.Api" Version="3.18.3.0" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.1.0" />
 		<PackageReference Include="TestCentric.Metadata" Version="3.0.4" />

--- a/src/TestEngine/testcentric.engine/testcentric.engine.csproj
+++ b/src/TestEngine/testcentric.engine/testcentric.engine.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00005" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00006" />
 		<PackageReference Include ="NUnit.Engine.Api" Version="3.18.3.0" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.1.0" />
 		<PackageReference Include="TestCentric.Metadata" Version="3.0.4" />


### PR DESCRIPTION
Follow-up to substantial changes in the api, updating to version 2.0.0-dev00005